### PR TITLE
Use disabled attributes for radio / checkbox form control when is reaondly

### DIFF
--- a/modules/adminui/lib/Form/ChoiceControlTrait.php
+++ b/modules/adminui/lib/Form/ChoiceControlTrait.php
@@ -1,0 +1,30 @@
+<?php
+/**
+* @author    Raphaël MARTIN
+* @copyright 2024 3liz.com
+*
+* @see      3liz.com
+*
+* @license   MIT
+*/
+
+namespace Jelix\AdminUI\Form;
+
+trait ChoiceControlTrait
+{
+    /**
+     * use parent method, and if readonly, add proper attributes
+     * Note that value won't be sent by submit but it is not a problem as it is readonly
+     * this method is usefull for radio and checkbox(es) controls
+     */
+    protected function getControlAttributes()
+    {
+        $attr = parent::getControlAttributes();
+        if ($this->ctrl->isReadOnly()) {
+            $attr['disabled'] = 'disabled';
+        } else {
+            unset($attr['disabled']);
+        }
+        return $attr;
+    }
+}

--- a/modules/adminui/plugins/formwidget/checkbox_adminlte/checkbox_adminlte.formwidget.php
+++ b/modules/adminui/plugins/formwidget/checkbox_adminlte/checkbox_adminlte.formwidget.php
@@ -11,6 +11,7 @@ require_once JELIX_LIB_PATH.'plugins/formwidget/checkbox_html/checkbox_html.form
 class checkbox_adminlteFormWidget extends checkbox_htmlFormWidget
 {
     use \Jelix\AdminUI\Form\WidgetTrait;
+    use \Jelix\AdminUI\Form\ChoiceControlTrait;
 
     protected function outputJs()
     {
@@ -51,11 +52,6 @@ class checkbox_adminlteFormWidget extends checkbox_htmlFormWidget
             $attr['value'] = $this->ctrl->valueOnCheck;
             $attr['id'] = $attrid.'_'.$this->ctrl->valueOnCheck;
 
-            // attribute readonly is not enough to make checkboxes readonly. Note that value won't be sent by submit but it is not a problem as it is readonly
-            if (array_key_exists('readonly', $attr)) {
-                $attr['disabled'] = 'disabled';
-            }
-
             echo '<input';
             $this->_outputAttr($attr);
             echo '/>';
@@ -87,10 +83,7 @@ class checkbox_adminlteFormWidget extends checkbox_htmlFormWidget
             }
             $attr['value'] = $this->ctrl->valueOnCheck;
             $attr['type'] = 'checkbox';
-            // attribute readonly is not enough to make checkboxes readonly. Note that value won't be sent by submit but it is not a problem as it is readonly
-            if (array_key_exists('readonly', $attr)) {
-                $attr['disabled'] = 'disabled';
-            }
+
             echo '<input';
             $this->_outputAttr($attr);
             echo '/>';

--- a/modules/adminui/plugins/formwidget/checkboxes_adminlte/checkboxes_adminlte.formwidget.php
+++ b/modules/adminui/plugins/formwidget/checkboxes_adminlte/checkboxes_adminlte.formwidget.php
@@ -11,6 +11,7 @@ require_once JELIX_LIB_PATH.'plugins/formwidget/checkboxes_html/checkboxes_html.
 class checkboxes_adminlteFormWidget extends checkboxes_htmlFormWidget
 {
     use \Jelix\AdminUI\Form\WidgetTrait;
+    use \Jelix\AdminUI\Form\ChoiceControlTrait;
 
     protected function getCSSClass()
     {

--- a/modules/adminui/plugins/formwidget/radiobuttons_adminlte/radiobuttons_adminlte.formwidget.php
+++ b/modules/adminui/plugins/formwidget/radiobuttons_adminlte/radiobuttons_adminlte.formwidget.php
@@ -12,6 +12,7 @@ require_once JELIX_LIB_PATH.'plugins/formwidget/radiobuttons_html/radiobuttons_h
 class radiobuttons_adminlteFormWidget extends radiobuttons_htmlFormWidget
 {
     use \Jelix\AdminUI\Form\WidgetTrait;
+    use \Jelix\AdminUI\Form\ChoiceControlTrait;
 
     protected function getCSSClass()
     {

--- a/test/modules/test/forms/formallwidgets.form.xml
+++ b/test/modules/test/forms/formallwidgets.form.xml
@@ -100,6 +100,26 @@
         <item value="assiette">a plate</item>
     </checkboxes>
 
+    <checkboxes ref="outerspace_house" readonly='true'>
+        <label>You own an house on  </label>
+        <item value="mars">Mars</item>
+        <item value="moon">Moon</item>
+        <item value="pluto">Pluto</item>
+    </checkboxes>
+
+    <radiobuttons ref="superhero" readonly='true'>
+        <label>You are </label>
+        <item value="bat">batman</item>
+        <item value="spider">spiderman</item>
+        <item value="iron">ironman</item>
+    </radiobuttons>
+
+    <checkbox ref="no_awnser_possible" readonly='true'>
+        <label>Question ?</label>
+        <oncheckvalue label="yes" />
+        <onuncheckvalue label="no" />
+    </checkbox>
+
     <date ref="birthdaydate">
         <label>Your birthday</label>
     </date>


### PR DESCRIPTION
When control is readonly, the radio and checkbox control were still enabled whereas the choice is useless, attribute `disabled` was missing

Use a trait and refacto the code for `checkbox`

Screenshot : from 
![Screenshot 2024-08-30 at 10-43-21 ](https://github.com/user-attachments/assets/fdc1a325-e79d-4b53-9275-dcb4e7b5f32e)
to
![Screenshot 2024-08-30 at 10-40-02 ](https://github.com/user-attachments/assets/d9ccbd5b-6962-4aa6-88a3-1d4c53de4032)
