### PR TITLE
Adminui meta plugin to allow to define page title and sub title in template

### DIFF
--- a/modules/adminui/plugins/tpl/html/meta.adminui.php
+++ b/modules/adminui/plugins/tpl/html/meta.adminui.php
@@ -1,0 +1,48 @@
+<?php
+/**
+* @author    Raphaël MARTIN
+* @copyright 2024 3liz.com
+*
+* @see      3liz.com
+*
+* Inspired by jelix meta_html plugin that allow to define values in template
+* that will be used in the response object
+* very usefull when you want to overwite values defined by an external module
+* simply by overriding template
+*/
+
+/**
+ * Method jtpl_meta_html_adminui
+ *
+ * @param jTpl   $tpl           template engine
+ * @param string $metaAttribute the item you want to change id response (possible value :
+ *                              page_title, sub_page_title, page_title_locale, sub_page_title_locale)
+ * @param mixed  $param         value for the item (exemple : the title for item "page_title")
+ * @param array  $params        additional parameters
+ *
+ * @return void
+ */
+function jtpl_meta_html_adminui($tpl, $metaAttribute, $param = null, $params = array())
+{
+    $resp = jApp::coord()->response;
+
+    if ($resp->getType() != 'html') {
+        return;
+    }
+    switch ($metaAttribute) {
+        case 'page_title': case 'sub_page_title':
+            $resp->body->assign($metaAttribute, $param);
+
+            break;
+        case 'page_title_locale': case 'sub_page_title_locale':
+            try {
+                $localisedValue = jLocale::get($param, $params);
+                $tplVarName = substr($metaAttribute, 0, -7);
+                $resp->body->assign($tplVarName, $localisedValue);
+            } catch (\Exception $e) {
+                // log exception
+                \jLog::logEx($e, 'error');
+            }
+    }
+
+}

--- a/test/modules/test/controllers/default.classic.php
+++ b/test/modules/test/controllers/default.classic.php
@@ -127,8 +127,6 @@ class defaultCtrl extends jController
 
         $tpl->assign('form', $form);
 
-        $rep->body->assign('page_title', 'A form');
-        $rep->body->assign('sub_page_title', 'Show all jForms widgets for AdminLte');
         $tpl->assign('customform' , $this->param('custom'));
         $rep->body->assign('MAIN', $tpl->fetch('test~form'));
         return $rep;

--- a/test/modules/test/locales/fr_FR/test.UTF-8.properties
+++ b/test/modules/test/locales/fr_FR/test.UTF-8.properties
@@ -1,0 +1,3 @@
+
+dashboard.title=Tableau de bord
+dashboard.sub_title=Vraiment %s

--- a/test/modules/test/templates/dashboard.tpl
+++ b/test/modules/test/templates/dashboard.tpl
@@ -3,6 +3,9 @@
 {meta_html css 'https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css'}
 
 
+{meta_adminui page_title_locale 'test~test.dashboard.title'}
+{meta_adminui sub_page_title_locale 'test~test.dashboard.sub_title',array('génial')}
+
 <div class="row">
     <!-- Left col -->
     <section class="col-lg-7 connectedSortable">

--- a/test/modules/test/templates/form.tpl
+++ b/test/modules/test/templates/form.tpl
@@ -1,3 +1,7 @@
+{meta_html title 'Form example' }
+{meta_adminui page_title 'A form'}
+{meta_adminui sub_page_title 'Show all jForms widgets for AdminLte'}
+
 {if $customform}
     <p>Custom form template. <a href="{jurl 'test~default:form'}">Switch to automatic form template</a>.</p>
     <div class="card card-success">


### PR DESCRIPTION
simple mode : 
````tpl

{meta_adminui page_title 'My Title'}
````
or using locales : 
````tpl

{meta_adminui page_title_locale 'test~test.dashboard.title'}
{* or with params *}
{meta_adminui page_title_locale 'test~test.dashboard.title' , array() }
````